### PR TITLE
refactor(start-script): breakout for arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "ng": "ng",
     "nx": "nx",
-    "start": "concurrently -k \"ng serve\" \"ng serve api\"",
+    "start": "concurrently -k \"yarn start-frontend\" \"yarn start-backend\"",
+    "start-frontend": "ng serve --live-reload false",
+    "start-backend": "ng serve api",
     "build": "ng build",
     "test": "ng test",
     "lint": "nx workspace-lint && ng lint",


### PR DESCRIPTION
The "start" script for the default app was getting too long.